### PR TITLE
Improve Pi setup steps

### DIFF
--- a/example/pi-service/Makefile
+++ b/example/pi-service/Makefile
@@ -6,13 +6,15 @@ install-pypy:
 	sudo mv pypy-4.0.1-linux-armhf-raspbian /usr/local/
 	sudo chmod -R ugo+x /usr/local/pypy-4.0.1-linux-armhf-raspbian 
 	sudo chown -R root:staff /usr/local/pypy-4.0.1-linux-armhf-raspbian 
-	sudo ln -s /usr/local/pypy-4.0.1-linux-armhf-raspbian/bin/pypy ~/bin/ 
-	
+
 pypy-get-pip:
 	sudo /usr/local/pypy-4.0.1-linux-armhf-raspbian/bin/pypy ./get-pip.py
 
 install-txnats:
 	sudo /usr/local/pypy-4.0.1-linux-armhf-raspbian/bin/pip install txnats
+
+link-pypy:
+	sudo ln -s /usr/local/pypy-4.0.1-linux-armhf-raspbian/bin/pypy ~/bin/ 
 
 add-services:
 	sudo cp nats.respond.1.service /etc/systemd/system/nats.respond.1.service

--- a/example/pi-service/README.md
+++ b/example/pi-service/README.md
@@ -27,6 +27,10 @@ Steps:
  - `make pypy-get-pip`
  - `make install-txnats`
 
+Optionally link pypy to your home bin directory, so you can run pypy without entering the whole path.
+ - If it doesn't exist add a bin directory to your home directory. `mkdir ~/bin`
+ - `make link-pypy`
+
 Setup and start the services
 This will make four copies of the respond service.
  - `make add-services`


### PR DESCRIPTION
Make one step optional and later.

Running through this with a second Raspberry Pi, the part
where it links pypy to my home bin directory caused a problem.
Not only did it error because I didn't already have `~/bin` created,
but it caused a problem with get-pip.py, somewhere using ~/bin
as it's relative install directory.
