### PR TITLE
On a connection failure, stop the reactor

### DIFF
--- a/example/queue_respond.py
+++ b/example/queue_respond.py
@@ -56,10 +56,17 @@ def create_client(reactor, host, port):
     # connectProtocol knows how to connected to the endpoint.
     connecting = connectProtocol(point, nats_protocol)
     # Log if there is an error making the connection.
-    connecting.addErrback(lambda np: log.info("{p}", p=np))
+    connecting.addErrback(on_fail_to_connect, nats_protocol)
     # Log what is returned by the connectProtocol.
     connecting.addCallback(lambda np: log.info("{p}", p=np))
     return connecting
+
+
+def on_fail_to_connect(error, nats_protocol):
+    """Exit on failure, the process manager
+    should try restarting, (systemd)"""
+    log.error("{error}", error=error)
+    nats_protocol.reactor.stop()
 
 
 def main(reactor):


### PR DESCRIPTION
This gives any process manager to try again.

For now, this is only in one example to try out the technique. It seems like a good thing since it let's systemd do what it does best and not try to reproduce it. If the device this is running on 
hasn't established it's network connection yet, it will be able to try again and connect when
the network is working.
