### PR TITLE
Raspberry Pi Sense Hat LED control example

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,10 @@
+# Command and control
+
+Run `python sense_led_serve.py` from a Raspberry Pi with a SenseHat installed
+
+Run `send_sense.py` from another computer to send messages to be displayed on the SenseHat's 8x8 LED grid.
+
+This is an example of controlling devices over the network.
+
+Recommend to downloading the gnatsd server from [nats.io](http://nats.io) and running it and then run these scripts with `--host` set to the address of the computer running it.
+

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,13 @@
 
 Run `python sense_led_serve.py` from a Raspberry Pi with a SenseHat installed
 
+
 Run `send_sense.py` from another computer to send messages to be displayed on the SenseHat's 8x8 LED grid.
+
+```
+$python send_sense.py hello, world
+
+```
 
 This is an example of controlling devices over the network.
 

--- a/example/README.md
+++ b/example/README.md
@@ -6,5 +6,5 @@ Run `send_sense.py` from another computer to send messages to be displayed on th
 
 This is an example of controlling devices over the network.
 
-Recommend to downloading the gnatsd server from [nats.io](http://nats.io) and running it and then run these scripts with `--host` set to the address of the computer running it.
+I recommend downloading the `gnatsd` server from [nats.io](http://nats.io) and running it and then run these scripts with `--host` set to the address of the computer running it.
 

--- a/example/send_sense.py
+++ b/example/send_sense.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from sys import stdout
+import random
+import string
+
+import txnats
+
+from twisted.logger import globalLogPublisher
+from simple_log_observer import simpleObserver
+
+from twisted.logger import Logger
+log = Logger()
+
+from twisted.internet import defer
+from twisted.internet import task
+from twisted.internet import reactor
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.endpoints import connectProtocol
+
+
+client_id = ''.join(
+    random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+
+
+def sid_on_msg(nats_protocol, sid, subject, reply_to, payload):
+    stdout.write("sid: {}, subject: {}, reply-to: {}\r\n".format(
+        sid, subject, reply_to))
+    stdout.write(payload.decode())
+    stdout.write("\r\n*")
+
+
+def sleep(own_reactor, seconds):
+    d = defer.Deferred()
+    own_reactor.callLater(seconds, d.callback, seconds)
+    return d
+
+
+@defer.inlineCallbacks
+def someRequests(nats_protocol):
+    """
+    The only point of this code is to show some basic subscribing
+    and publishing.
+    """
+    client_inbox = "inbox_{}".format(client_id)
+    nats_protocol.sub(client_inbox, 1, on_msg=sid_on_msg)
+    for x in range(4):
+        nats_protocol.pub("senseshow",
+                          "{}".format(x).encode(),
+                          client_inbox)
+        log.info("sent: {}".format(x))
+        yield sleep(nats_protocol.reactor, 0.01)
+
+    # Lose the connection one second after the "and another thing" msg.
+    yield task.deferLater(nats_protocol.reactor,
+                          10, nats_protocol.transport.loseConnection)
+
+    # stop the reactor(the event loop) one second after that.
+    yield task.deferLater(nats_protocol.reactor, 1, reactor.stop)
+
+
+def main(reactor):
+
+    host = "demo.nats.io"
+    host = "localhost"
+    port = 4222
+
+    point = TCP4ClientEndpoint(reactor, host, port)
+    nats_protocol = txnats.io.NatsProtocol(
+        verbose=False,
+        on_connect=someRequests)
+
+    connecting = connectProtocol(point, nats_protocol)
+    # Log if there is an error making the connection.
+    connecting.addErrback(lambda np: log.info("{p}", p=np))
+    # Log what is returned by the connectProtocol.
+    connecting.addCallback(lambda np: log.info("{p}", p=np))
+    return connecting
+
+
+if __name__ == '__main__':
+    globalLogPublisher.addObserver(simpleObserver)
+    main(reactor)
+    reactor.run()
+

--- a/example/sense_led_serve.py
+++ b/example/sense_led_serve.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from sys import stdout
+import random
+import string
+from sense_hat import SenseHat
+
+import txnats
+
+from twisted.logger import globalLogPublisher
+from simple_log_observer import simpleObserver
+from twisted.logger import Logger
+log = Logger()
+
+from twisted.internet import reactor
+from twisted.internet import defer
+from twisted.internet.threads import deferToThread
+from twisted.internet.endpoints import TCP4ClientEndpoint
+from twisted.internet.endpoints import connectProtocol
+
+responder_id = ''.join(
+    random.choice(string.ascii_uppercase + string.digits) for _ in range(8))
+
+sem = defer.DeferredSemaphore(1)
+sense = SenseHat()
+
+
+@defer.inlineCallbacks
+def show_msg(message):
+    yield deferToThread(
+        sense.show_message, text_string=message,
+        scroll_speed=0.10, text_colour=(50, 100, 40))
+
+
+@defer.inlineCallbacks
+def respond_on_msg(nats_protocol, sid, subject, reply_to, payload):
+    """
+    Write the message payload to standard out, and if
+    there is a reply_to, publish a message to it.
+    """
+    yield sem.run(show_msg, payload.decode())
+    if reply_to:
+        nats_protocol.pub(reply_to, "Roger, from {}!".format(responder_id))
+
+
+def listen(nats_protocol):
+    """
+    When the protocol is first connected, make a subscription.
+    """
+    nats_protocol.sub("senseshow", 1,
+                      on_msg=respond_on_msg)
+
+
+def create_client(reactor, host, port):
+    """
+    Start a Nats Protocol and connect it to a NATS endpoint over TCP4
+    which subscribes a subject with a callback that sends a response
+    if it gets a reply_to.
+    """
+    log.info("Start client.")
+    point = TCP4ClientEndpoint(reactor, host, port)
+    nats_protocol = txnats.io.NatsProtocol(verbose=False, on_connect=listen)
+
+    # Because NatsProtocol implements the Protocol interface, Twisted's
+    # connectProtocol knows how to connected to the endpoint.
+    connecting = connectProtocol(point, nats_protocol)
+    # Log if there is an error making the connection.
+    connecting.addErrback(lambda np: log.info("{p}", p=np))
+    # Log what is returned by the connectProtocol.
+    connecting.addCallback(lambda np: log.info("{p}", p=np))
+    return connecting
+
+
+def main(reactor):
+
+    host = "demo.nats.io"
+    host = "192.168.86.160"
+    port = 4222
+
+    create_client(reactor, host, port)
+
+if __name__ == '__main__':
+    globalLogPublisher.addObserver(simpleObserver)
+    main(reactor)
+    reactor.run()
+


### PR DESCRIPTION
Run `sense_led_serve.py` from a Raspberry Pi with a SenseHat installed

Run `send_sense` from another computer to send messages to be displayed on the SenseHat's 8x8 LED grid.

This is an example of controlling devices over the network.

Recommend to downloading the gnatsd server from http://nats.io and running it
and then run these scripts with --host set to the address of the computer running it.
