### PR TITLE
Make debugging easier by printing unhandled failure tracebacks

### DIFF
--- a/example/make_requests.py
+++ b/example/make_requests.py
@@ -40,7 +40,7 @@ def someRequests(nats_protocol):
     client_inbox = "inbox_{}".format(client_id)
     nats_protocol.sub(client_inbox, "1", on_msg=sid_on_msg)
     for x in range(100):
-        nats_protocol.pub("a-queue",
+        nats_protocol.pub("aQueue",
                           "Do something! {}".format(x).encode(),
                           client_inbox)
 

--- a/tests/test_on_connect.py
+++ b/tests/test_on_connect.py
@@ -1,0 +1,41 @@
+from io import BytesIO
+
+from twisted.trial import unittest
+from twisted.internet import task
+from twisted.internet import defer
+
+
+import txnats
+
+
+class ErrorTest(unittest.TestCase):
+    maxDiff = None
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        """
+        Create protocol.
+
+        Add any fixtures.
+
+        :return:
+        """
+        yield
+
+    def test_on_connect_error(self):
+        """
+        Ensure an unhandled error in an on connect function is reported.
+        """
+        def on_connect(protocol):
+            raise ValueError("It is wrong.")
+
+        nats_protocol = txnats.io.NatsProtocol(own_reactor=task.Clock(), on_connect=on_connect)
+        nats_protocol.on_connect_d.callback(nats_protocol)
+        self.failureResultOf(nats_protocol.on_connect_d, ValueError)
+
+    def tearDown(self):
+        """
+        Any tear down.
+
+        :return:
+        """

--- a/txnats/_meta.py
+++ b/txnats/_meta.py
@@ -1,2 +1,2 @@
-version_info = (0, 7, 3)
+version_info = (0, 7, 4)
 version = '.'.join(map(str, version_info))

--- a/txnats/protocol.py
+++ b/txnats/protocol.py
@@ -98,7 +98,6 @@ class NatsProtocol(Protocol):
         return r'<NatsProtocol connected={} server_info={}>'.format(self.status, self.server_settings)
 
     def _eb_trace_and_raise(self, failure):
-        #self.log.failure("Unhandled Error during on_connect", failure=failure)
         failure.printTraceback()
         failure.raiseException()
 

--- a/txnats/protocol.py
+++ b/txnats/protocol.py
@@ -88,6 +88,7 @@ class NatsProtocol(Protocol):
         self.on_connect_d = defer.Deferred()
         if on_connect:
             self.on_connect_d.addCallback(on_connect)
+            self.on_connect_d.addErrback(self._eb_trace_and_raise)
         self.sids = {}
         self.subscriptions = subscriptions if subscriptions is not None else {}
         self.unsubs = unsubs if unsubs else {}
@@ -95,6 +96,11 @@ class NatsProtocol(Protocol):
     
     def __repr__(self):
         return r'<NatsProtocol connected={} server_info={}>'.format(self.status, self.server_settings)
+
+    def _eb_trace_and_raise(self, failure):
+        #self.log.failure("Unhandled Error during on_connect", failure=failure)
+        failure.printTraceback()
+        failure.raiseException()
 
     def dispatch(self, event):
         """Call each event subscriber with the event.


### PR DESCRIPTION
Make debugging easier by printing unhandled failure tracebacks
Add test of on connect errors
Fix an error in an example